### PR TITLE
Fix disappearing navbar

### DIFF
--- a/src/components/LinkShadow.vue
+++ b/src/components/LinkShadow.vue
@@ -1,5 +1,7 @@
 <template>
-  <router-link class="btn btn-primary w-full font-bold" :to="to"><slot></slot></router-link>
+  <router-link class="btn btn-primary w-full font-bold" :to="to">
+    <slot></slot>
+  </router-link>
 </template>
 <script>
 export default {
@@ -13,9 +15,9 @@ export default {
   transition: all 200ms ease-in-out;
   box-shadow: 2px 5px 0 0 black;
 }
+
 .btn:hover,
 .btn:active {
   transform: translateY(4px) translateX(2px);
   box-shadow: 0 0 0 0 black;
-}
-</style>
+}</style>

--- a/src/components/MainNavbar.vue
+++ b/src/components/MainNavbar.vue
@@ -111,6 +111,8 @@ export default {
       var currentScrollPos = window.pageYOffset;
       if (document.querySelector('.hideonscroll.smallscreen'))
         document.querySelector('.hideonscroll.smallscreen').style.top = this.prevScrollpos > currentScrollPos ? "0" : "-77px";
+      else if (document.querySelector('.hideonscroll'))
+        document.querySelector('.hideonscroll').style.top = "0";
       this.prevScrollpos = currentScrollPos;
     }
   },

--- a/src/components/MainNavbar.vue
+++ b/src/components/MainNavbar.vue
@@ -108,12 +108,14 @@ export default {
     this.$emit('update:modelValue', document.querySelector('header').offsetHeight);
     this.prevScrollpos = window.pageYOffset;
     window.onscroll = function () {
-      var currentScrollPos = window.pageYOffset;
-      if (document.querySelector('.hideonscroll.smallscreen'))
+      if (document.querySelector('.hideonscroll.smallscreen')) {
+        var currentScrollPos = window.pageYOffset;
         document.querySelector('.hideonscroll.smallscreen').style.top = this.prevScrollpos > currentScrollPos ? "0" : "-77px";
-      else if (document.querySelector('.hideonscroll'))
+        this.prevScrollpos = currentScrollPos;
+      }
+      else if (document.querySelector('.hideonscroll')) {
         document.querySelector('.hideonscroll').style.top = "0";
-      this.prevScrollpos = currentScrollPos;
+      }
     }
   },
 };


### PR DESCRIPTION
This PR fixes the following issue:

Settings: 
navbar hideonscroll: true
navbar hideonlyonphone: true

When it happens:
When the original screen size is considered a phone screen and then it's changed to a bigger screen where the navbar shouldn't hide when page is scrolled down.

What happens:
The navbar disappears because the navbar style is not reevaluated when the screen size is not considered phone sized.

Solution:
When the screen size is bigger, the style is statically set to be shown. On phone screen it should work as it is used to.